### PR TITLE
change API schema for POST requests to the API endpoint

### DIFF
--- a/tests/tasks_test.py
+++ b/tests/tasks_test.py
@@ -30,22 +30,24 @@ def test_post_data(measurement, cfg):
     }
     data = json.loads(req.data)
     assert data == {
-        'timestamp': 1658758977000,
-        'sensor_id': 1,
-        'last_measurement_period': 60,
-        'time_since_report': 0,
-        'optical_range': 1.19,
-        'precipitation_type_msg': 'NP',
-        'obstruction_to_vision': 'HZ',
-        'receiver_bg_illumination': 0.06,
-        'water_in_precip': 0.0,
-        'temp': 20.5,
-        'nr_precip_particles': 0,
-        'transmission_eq': 2.51,
-        'exco_less_precip_particle': 2.51,
-        'backscatter_exco': 11.1,
-        'self_test': 'OOO',
-        'total_exco': 2.51,
+        'data': [{
+            'timestamp': 1658758977000,
+            'sensor_id': 1,
+            'last_measurement_period': 60,
+            'time_since_report': 0,
+            'optical_range': 1.19,
+            'precipitation_type_msg': 'NP',
+            'obstruction_to_vision': 'HZ',
+            'receiver_bg_illumination': 0.06,
+            'water_in_precip': 0.0,
+            'temp': 20.5,
+            'nr_precip_particles': 0,
+            'transmission_eq': 2.51,
+            'exco_less_precip_particle': 2.51,
+            'backscatter_exco': 11.1,
+            'self_test': 'OOO',
+            'total_exco': 2.51,
+        }],
     }
 
 

--- a/vpf_730/tasks.py
+++ b/vpf_730/tasks.py
@@ -25,7 +25,7 @@ def post_data(msg: Message, cfg: Config) -> None:
             'no values for endpoint or api_key provided in the cfg object',
         )
 
-    post_data = json.dumps(msg.blob._asdict()).encode()
+    post_data = json.dumps({'data': [msg.blob._asdict()]}).encode()
     req = urllib.request.Request(cfg.endpoint, data=post_data)
     req.add_header('Authorization', cfg.api_key)
     req.add_header('Content-Type', 'application/json')


### PR DESCRIPTION
the new schema can theoretically support multiple messages

```json
"data": [
    {"timestamp", ...},
    {"timestamp", ...},
    ...
]
```