### PR TITLE
add feature for sending manual commands to the Sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ VPF730_API_KEY=deadbeef vpf-730 sender \
 --post-endpoint "https://api.example/com/vpf-730/data"
 ```
 
+## `comm` CLI
+
+It is also possible to manually send `ASCII` commands to the sensor. `\r\n` must not be specified
+
+```bash
+vpf-730 comm --serial-port /dev/ttyUSB0 R?
+```
+
+Returns:
+
+```console
+ 200,2.515,16.5,12.2,5.00,12.3,00.00,00.00,101,086,000,02,03,00,+001.9,4040
+```
+
 ### as a package
 
 ```python

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -45,6 +45,14 @@ a remote server.
   --post-endpoint "https://api.example/com/vpf-730/data"
   ```
 
+- When using the `comm` interface to manually send `ASCII` commands to the Sensor.
+  Information about the available commands can be found in the [Biral VPF-730 Manual](https://www.biral.com/wp-content/uploads/2019/07/VPF-710-730-750-Manual-102186.08E.pdf)
+  starting on page 56. Get started with a remote self-test and monitoring message `R?`:
+
+  ```bash
+  vpf-730 comm --serial-port /dev/ttyUSB0 R?
+  ```
+
 - When building your own tooling see [Package](package) for detailed examples. Get started with:
 
   ```python

--- a/docs/source/package.md
+++ b/docs/source/package.md
@@ -69,9 +69,27 @@ class VPF730_extended(VPF730):
             now = datetime.now(timezone.utc)
         else:
             now = custom_time
-        with self._open_ser():
+        with self.open_ser():
             self._ser.write(f'%SD{now:%w%d%m%y}\r\n'.encode())
             self._ser.write(f'%ST{now:%H%M%S}\r\n'.encode())
+```
+
+We can also utilize the {func}`vpf_730.VPF730.send_command` method for using other commands.
+
+```python
+from vpf_730 import VPF730
+
+
+class VPF730_extended(VPF730):
+    def self_test(self) -> str:
+        """Execute a self test of the sensor by sending the R? command
+
+        :returns: A message formatted like this (more in the manual page 60):
+            100,2.509,24.1,12.3,5.01,12.5,00.00,00.00,100,105,107,00,00,00,+021.0,4063
+        """
+        with self.open_ser():
+            self_test_msg = self.send_command('R?')
+        return self_test_msg.decode()
 ```
 
 ## The Sender class

--- a/tests/vpf_730_test.py
+++ b/tests/vpf_730_test.py
@@ -147,6 +147,20 @@ def test_vpf_730_measure_not_polled_mode():
     assert m is None
 
 
+def test_vpf_730_send_command():
+    vpf730 = VPF730(port='/dev/ttyUSB0')
+    self_test_ret = b'100,2.509,24.1,12.3,5.01,12.5,00.00,00.00,100,105,107,00,00,00,+021.0,4063'  # noqa: E501
+    with (
+        mock.patch.object(Serial, 'write') as w,
+        mock.patch.object(Serial, 'read_until', return_value=self_test_ret),
+        mock.patch.object(Serial, 'open'),
+    ):
+        m = vpf730.send_command('R?')
+
+    w.assert_called_once_with(b'R?\r\n')
+    assert m == self_test_ret
+
+
 def test_fdict():
     fdict = FrozenDict({'test': 123})
     assert fdict['test'] == 123

--- a/vpf_730/vpf_730.py
+++ b/vpf_730/vpf_730.py
@@ -347,7 +347,9 @@ class VPF730:
             self._ser.close()
 
     def send_command(self, command: str) -> bytes:
-        """Send an ASCII command to the VPF-730
+        """Send an ASCII command to the VPF-730. A detailed description can be
+        found in the Biral VPF-XXX Manual starting on page 59:
+        https://www.biral.com/wp-content/uploads/2019/07/VPF-710-730-750-Manual-102186.08E.pdf
 
         :param command: A valid command e.g: ``D?``
 

--- a/vpf_730/vpf_730.py
+++ b/vpf_730/vpf_730.py
@@ -346,6 +346,18 @@ class VPF730:
         finally:
             self._ser.close()
 
+    def send_command(self, command: str) -> bytes:
+        """Send an ASCII command to the VPF-730
+
+        :param command: A valid command e.g: ``D?``
+
+        :return: the response of the sensor as bytest
+        """
+        with self.open_ser():
+            cmd = f'{command}\r\n'
+            self._ser.write(cmd.encode())
+            return self._ser.read_until(b'\r\n')
+
     def measure(self, polled_mode: bool = True) -> Measurement | None:
         """Read the VPF-730 sensor using the previously configured serial
         interface and return a :func:`Measurement` or None, if the sensor did


### PR DESCRIPTION
one can now use 
```bash
vpf-730 comm --serial-port /dev/ttyUSB0 R?
```
to manually interact with the sensor